### PR TITLE
[CORE-3139] Add test case, and fix it again

### DIFF
--- a/liquibase-core/src/main/java/liquibase/resource/ClassLoaderResourceAccessor.java
+++ b/liquibase-core/src/main/java/liquibase/resource/ClassLoaderResourceAccessor.java
@@ -93,6 +93,13 @@ public class ClassLoaderResourceAccessor extends AbstractResourceAccessor {
                 if (path.startsWith("classpath*:")) {
                     path = path.replaceFirst("classpath\\*:", "");
                 }
+                // if path is like 'jar:<url>!/{entry}', use the last part as resource path
+                if (path.contains("!/")) {
+                    String[] components = path.split("!/");
+                    if (components.length > 1) {
+                        path = components[components.length - 1];
+                    }
+                }
 
                 // TODO:When we update to Java 7+, we can can create a FileSystem from the JAR (zip)
                 // file, and then use NIO's directory walking and filtering mechanisms to search through it.

--- a/liquibase-core/src/test/groovy/liquibase/resource/ClassLoaderResourceAccessorTest.groovy
+++ b/liquibase-core/src/test/groovy/liquibase/resource/ClassLoaderResourceAccessorTest.groovy
@@ -61,4 +61,19 @@ class ClassLoaderResourceAccessorTest extends Specification {
         listedResources.contains("org/springframework/core/io/Resource.class")
         !listedResources.contains("org/springframework/core/io/support/ResourcePatternUtils.class")
     }
+
+    // Test case for [CORE-3139]
+    def "can recursively enumerate files inside JARs using JAR file URL"() {
+        given:
+        def accessor = new ClassLoaderResourceAccessor(Thread.currentThread().contextClassLoader)
+        def jarPkgURL = this.getClass().getClassLoader().getResource("org/springframework/core/io/").toExternalForm()
+
+        when:
+        def listedResources = accessor.list(null, jarPkgURL, true, false, true)
+
+        then:
+        listedResources.contains("org/springframework/core/io/Resource.class")
+        listedResources.contains("org/springframework/core/io/support/ResourcePatternUtils.class")
+    }
+
 }


### PR DESCRIPTION
Although [CORE-3139](https://liquibase.jira.com/browse/CORE-3139) was fixed by #725 and has been merged, but the issue still exists in v3.6.1, and the files changed by #725 seems to be overwritten by some commit.

So I add a test case for CORE-3139, and fix it again.